### PR TITLE
Changed function signature from rest.API to rest.Send

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ func main() {
 		Method:  method,
 		BaseURL: baseURL,
 	}
-	response, err := rest.API(request)
+	response, err := rest.Send(request)
 	if err != nil {
 		fmt.Println(err)
 	} else {
@@ -80,7 +80,7 @@ func main() {
 		QueryParams: queryParams,
 		Body:        Body,
 	}
-	response, err := rest.API(request)
+	response, err := rest.Send(request)
 	if err != nil {
 		fmt.Println(err)
 	} else {

--- a/examples/example.go
+++ b/examples/example.go
@@ -34,7 +34,7 @@ func main() {
 		Headers:     Headers,
 		QueryParams: queryParams,
 	}
-	response, err := rest.API(request)
+	response, err := rest.Send(request)
 	if err != nil {
 		fmt.Println(err)
 	} else {
@@ -61,7 +61,7 @@ func main() {
 		QueryParams: queryParams,
 		Body:        Body,
 	}
-	response, err = rest.API(request)
+	response, err = rest.Send(request)
 	if err != nil {
 		fmt.Println(err)
 	} else {
@@ -91,7 +91,7 @@ func main() {
 		BaseURL: baseURL + "/" + apiKey,
 		Headers: Headers,
 	}
-	response, err = rest.API(request)
+	response, err = rest.Send(request)
 	if err != nil {
 		fmt.Println(err)
 	} else {
@@ -112,7 +112,7 @@ func main() {
 		Headers: Headers,
 		Body:    Body,
 	}
-	response, err = rest.API(request)
+	response, err = rest.Send(request)
 	if err != nil {
 		fmt.Println(err)
 	} else {
@@ -137,7 +137,7 @@ func main() {
 		Headers: Headers,
 		Body:    Body,
 	}
-	response, err = rest.API(request)
+	response, err = rest.Send(request)
 	if err != nil {
 		fmt.Println(err)
 	} else {
@@ -155,7 +155,7 @@ func main() {
 		Headers:     Headers,
 		QueryParams: queryParams,
 	}
-	response, err = rest.API(request)
+	response, err = rest.Send(request)
 	if err != nil {
 		fmt.Println(err)
 	} else {

--- a/rest.go
+++ b/rest.go
@@ -89,7 +89,7 @@ func BuildResponse(res *http.Response) (*Response, error) {
 	return &response, nil
 }
 
-// API is the main interface to the API.
+// Send is the main interface to the API.
 func Send(request Request) (*Response, error) {
 	return DefaultClient.Send(request)
 }
@@ -102,7 +102,7 @@ func (c *Client) MakeRequest(req *http.Request) (*http.Response, error) {
 	return c.HTTPClient.Do(req)
 }
 
-// API is the main interface to the API.
+// Send is the main interface to the API.
 func (c *Client) Send(request Request) (*Response, error) {
 	// Add any query parameters to the URL.
 	if len(request.QueryParams) != 0 {

--- a/rest.go
+++ b/rest.go
@@ -91,7 +91,7 @@ func BuildResponse(res *http.Response) (*Response, error) {
 
 // API is the main interface to the API.
 func Send(request Request) (*Response, error) {
-	return DefaultClient.API(request)
+	return DefaultClient.Send(request)
 }
 
 // The following functions enable the ability to define a

--- a/rest.go
+++ b/rest.go
@@ -90,7 +90,7 @@ func BuildResponse(res *http.Response) (*Response, error) {
 }
 
 // API is the main interface to the API.
-func API(request Request) (*Response, error) {
+func Send(request Request) (*Response, error) {
 	return DefaultClient.API(request)
 }
 
@@ -103,7 +103,7 @@ func (c *Client) MakeRequest(req *http.Request) (*http.Response, error) {
 }
 
 // API is the main interface to the API.
-func (c *Client) API(request Request) (*Response, error) {
+func (c *Client) Send(request Request) (*Response, error) {
 	// Add any query parameters to the URL.
 	if len(request.QueryParams) != 0 {
 		request.BaseURL = AddQueryParameters(request.BaseURL, request.QueryParams)

--- a/rest_test.go
+++ b/rest_test.go
@@ -95,7 +95,7 @@ func TestRest(t *testing.T) {
 		Headers:     Headers,
 		QueryParams: queryParams,
 	}
-	response, e := API(request)
+	response, e := Send(request)
 	if response.StatusCode != 200 {
 		t.Error("Invalid status code")
 	}

--- a/rest_test.go
+++ b/rest_test.go
@@ -156,7 +156,7 @@ func TestCustomHTTPClient(t *testing.T) {
 		BaseURL: baseURL,
 	}
 	customClient := &Client{&http.Client{Timeout: time.Millisecond * 10}}
-	_, err := customClient.API(request)
+	_, err := customClient.Send(request)
 	if err == nil {
 		t.Error("A timeout did not trigger as expected")
 	}


### PR DESCRIPTION
This PR changes the function signature from API to Send as raised in issue #13 .
This must be able to resolve issue #13 .
