### PR TITLE
Add RestError Struct for an error handling.

### DIFF
--- a/rest.go
+++ b/rest.go
@@ -29,6 +29,16 @@ type Request struct {
 	Body        []byte
 }
 
+// RestError is a struct for an error handling.
+type RestError struct {
+	Response *Response
+}
+
+// Error is the implementation of the error interface.
+func (e *RestError) Error() string {
+	return e.Response.Body
+}
+
 // DefaultClient is used if no custom HTTP client is defined
 var DefaultClient = &Client{HTTPClient: http.DefaultClient}
 

--- a/rest_test.go
+++ b/rest_test.go
@@ -164,3 +164,27 @@ func TestCustomHTTPClient(t *testing.T) {
 		t.Error("We did not receive the Timeout error")
 	}
 }
+
+func TestRestError(t *testing.T) {
+	headers := make(map[string][]string)
+	headers["Content-Type"] = []string{"application/json"}
+
+	response := &Response{
+		StatusCode: 400,
+		Body:       `{"result": "failure"}`,
+		Headers:    headers,
+	}
+
+	restErr := &RestError{Response: response}
+
+	var err error
+	err = restErr
+
+	if _, ok := err.(*RestError); !ok {
+		t.Error("RestError does not satisfiy the error interface.")
+	}
+
+	if err.Error() != `{"result": "failure"}` {
+		t.Error("Invalid error message.")
+	}
+}


### PR DESCRIPTION
I've implemented RestError Struct.
refs #17 

I understood that sendgrid/sendgrid-go will remove dependence on sendgrid/rest. I'll consider about  sendgrid-go, at the first, I would like to send this PR.
