### PR TITLE
Added License test

### DIFF
--- a/license_test.go
+++ b/license_test.go
@@ -1,0 +1,27 @@
+package rest
+
+import (
+	"fmt"
+	"io/ioutil"
+	"regexp"
+	"testing"
+	"time"
+)
+
+func TestLicense(t *testing.T) {
+	re, _ := regexp.Compile("[0-9]{4}")
+
+	f, err := ioutil.ReadFile("LICENSE.txt")
+
+	if err != nil {
+		t.Errorf("could not read file: %v", err)
+	}
+
+	currentYear := fmt.Sprint(time.Now().Year())
+	specifiedYear := string(re.Find(f))
+
+	if specifiedYear != currentYear {
+		t.Errorf("Specified year (%s) is different of the current year (%s)", specifiedYear, currentYear)
+	}
+
+}


### PR DESCRIPTION
This tests if the year specified in the LICENSE.txt file is equal to the current year. If not it fails with a message: "Specified year is different of the current year".