### PR TITLE
Include Gometalinter in Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,12 @@ go:
 - 1.8.x
 - 1.9.x
 - tip
-script: go test -race -cover -v ./...
+before_script:
+- go get -u github.com/alecthomas/gometalinter
+- gometalinter --install
+script:
+- gometalinter --disable=golint ./...
+- go test -race -cover -v ./...
 notifications:
   hipchat:
     rooms:

--- a/rest.go
+++ b/rest.go
@@ -97,7 +97,9 @@ func BuildResponse(res *http.Response) (*Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer res.Body.Close()
+	defer func() {
+		_ = res.Body.Close()
+	}()
 	response := Response{
 		StatusCode: res.StatusCode,
 		Body:       string(body),

--- a/rest_test.go
+++ b/rest_test.go
@@ -98,7 +98,13 @@ func TestBuildResponse(t *testing.T) {
 		BaseURL: baseURL,
 	}
 	req, e := BuildRequestObject(request)
+	if e != nil {
+		t.Error("Failed to BuildRequestObject", e)
+	}
 	res, e := MakeRequest(req)
+	if e != nil {
+		t.Error("Failed to MakeRequest", e)
+	}
 	response, e := BuildResponse(res)
 	if response.StatusCode != 200 {
 		t.Error("Invalid status code in BuildResponse")
@@ -173,6 +179,9 @@ func TestRest(t *testing.T) {
 
 	//Start Print Request
 	req, e := BuildRequestObject(request)
+	if e != nil {
+		t.Errorf("Error during BuildRequestObject: %v", e)
+	}
 	requestDump, err := httputil.DumpRequest(req, true)
 	if err != nil {
 		t.Errorf("Error : %v", err)
@@ -268,7 +277,7 @@ func TestCustomHTTPClient(t *testing.T) {
 	if err == nil {
 		t.Error("A timeout did not trigger as expected")
 	}
-	if strings.Contains(err.Error(), "Client.Timeout exceeded while awaiting headers") == false {
+	if !strings.Contains(err.Error(), "Client.Timeout exceeded while awaiting headers") {
 		t.Error("We did not receive the Timeout error")
 	}
 }
@@ -284,14 +293,7 @@ func TestRestError(t *testing.T) {
 		Headers:    headers,
 	}
 
-	restErr := &RestError{Response: response}
-
-	var err error
-	err = restErr
-
-	if _, ok := err.(*RestError); !ok {
-		t.Error("RestError does not satisfy the error interface.")
-	}
+	var err error = &RestError{Response: response}
 
 	if err.Error() != `{"result": "failure"}` {
 		t.Error("Invalid error message.")


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.


Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->
# Fixes #57 

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation about the functionality in the appropriate .md file
- [x] I have added in line documentation to the code I modified

### Short description of what this PR does:
- Added the [gometalinter](https://github.com/alecthomas/gometalinter) to the TravisCI build
- Enabled all linters with the exception of `golint` because golint is suggesting a change to an exported type which will break the public API.
- Invoked [gometalinter](https://github.com/alecthomas/gometalinter) on `./...`.
- Fixed a few small issues found by the enabled linters.
```
gometalinter --disable=golint ./...
rest_test.go:100:7:warning: ineffectual assignment to e (ineffassign)
rest_test.go:101:7:warning: ineffectual assignment to e (ineffassign)
rest_test.go:175:7:warning: ineffectual assignment to e (ineffassign)
rest.go:100:22:warning: error return value not checked (defer res.Body.Close()) (errcheck)
rest_test.go:100:7:warning: this value of e is never used (SA4006) (megacheck)
rest_test.go:101:7:warning: this value of e is never used (SA4006) (megacheck)
rest_test.go:175:7:warning: this value of e is never used (SA4006) (megacheck)
rest_test.go:271:5:warning: should omit comparison to bool constant, can be simplified to !strings.Contains(err.Error(), "Client.Timeout exceeded while awaiting headers") (S1002) (megacheck)
rest_test.go:289:2:warning: should merge variable declaration with assignment on next line (S1021) (megacheck)
```

The `golint` issue should be fixed in another issue that communicates the breaking public API.
```
gometalinter --disable-all --enable=golint ./...
rest.go:33:6:warning: type name will be used as rest.RestError by other packages, and that stutters; consider calling this Error (golint)
```

If you have questions, please send an email to [Sendgrid](mailto:dx@sendgrid.com), or file a Github Issue in this repository.
