### PR TITLE
Add fallback functionality for Client.API()

### DIFF
--- a/rest.go
+++ b/rest.go
@@ -124,6 +124,11 @@ func (c *Client) MakeRequest(req *http.Request) (*http.Response, error) {
 	return c.HTTPClient.Do(req)
 }
 
+// Function for support old implementation (deprecated)
+func (c *Client) API(request Request) (*Response, error) {
+	return Send(request)
+}
+
 // API is the main interface to the API.
 func (c *Client) Send(request Request) (*Response, error) {
 	// Build the HTTP request object.

--- a/rest.go
+++ b/rest.go
@@ -126,7 +126,7 @@ func (c *Client) MakeRequest(req *http.Request) (*http.Response, error) {
 
 // Function for support old implementation (deprecated)
 func (c *Client) API(request Request) (*Response, error) {
-	return Send(request)
+	return c.Send(request)
 }
 
 // API is the main interface to the API.


### PR DESCRIPTION
# Fixes # 
Fixes #67

### Checklist
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [x] I have added in line documentation to the code I modified

### Short description of what this PR does:
-  While the recent change from #19 added fallback functionality for the global available API function, it did not add fallback functionality for the API function in the Client, breaking the Sendgrid Go client and possibly other implementations.
