### PR TITLE
Don't swallow the error code

### DIFF
--- a/rest.go
+++ b/rest.go
@@ -94,20 +94,13 @@ func MakeRequest(req *http.Request) (*http.Response, error) {
 // BuildResponse builds the response struct.
 func BuildResponse(res *http.Response) (*Response, error) {
 	body, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		if err := res.Body.Close(); err != nil {
-			return // maybe log in the future
-		}
-	}()
 	response := Response{
 		StatusCode: res.StatusCode,
 		Body:       string(body),
 		Headers:    res.Header,
 	}
-	return &response, nil
+	res.Body.Close() // nolint
+	return &response, err
 }
 
 // API supports old implementation (deprecated)
@@ -148,10 +141,5 @@ func (c *Client) Send(request Request) (*Response, error) {
 	}
 
 	// Build Response object.
-	response, err := BuildResponse(res)
-	if err != nil {
-		return nil, err
-	}
-
-	return response, nil
+	return BuildResponse(res)
 }

--- a/rest_test.go
+++ b/rest_test.go
@@ -147,12 +147,9 @@ func TestBuildBadResponse(t *testing.T) {
 	res := &http.Response{
 		Body: new(panicResponse),
 	}
-	response, e := BuildResponse(res)
+	_, e := BuildResponse(res)
 	if e == nil {
 		t.Errorf("This was a bad response and error should be returned")
-	}
-	if response != nil {
-		t.Errorf("Response is not nil which shouldn't be possible")
 	}
 }
 


### PR DESCRIPTION
When io.ReadAll fails we get no information on the request.

It's annoying, as error code are usually really useful in those case.

### Checklist
- [X] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [X] I have read the [Contribution Guide] and my PR follows them.
- [X] I updated my branch with the master branch.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added in line documentation to the code I modified

### Short description of what this PR does:
-  Returns the response object with an error to help treat the error 