### PR TITLE
Script to generate changelog entries for new releases

### DIFF
--- a/scripts/changelog.go
+++ b/scripts/changelog.go
@@ -148,6 +148,7 @@ func collectAuthors(prs []pullRequest) []string {
 			continue
 		}
 		if _, ok := seen[pr.Author]; !ok {
+			seen[pr.Author] = true
 			authors = append(authors, pr.Author)
 		}
 	}

--- a/scripts/changelog.go
+++ b/scripts/changelog.go
@@ -26,7 +26,7 @@ const (
 {{ if .Authors -}}
 - Special thanks for these PRs to:
 {{- range .Authors }}
-    - @{{ . }}
+    - [{{ . }}](//github.com/{{ . }})
 {{- end }}
 {{- else -}}
 - No PRs were merged in this release.

--- a/scripts/changelog.go
+++ b/scripts/changelog.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+	"text/template"
+	"time"
+)
+
+const (
+	prefix   = "v"
+	branch   = "master"
+	prTitle  = "Merge pull request #(\\d+) from (\\w*)"
+	clFormat = `## [{{ .Version }}] - {{ .Date }}
+### Merged
+{{- range .PullRequests }}
+- Pull #{{ .Number }}: {{ .Commit.Body }}
+{{- end }}
+{{ if .Authors -}}
+- Special thanks for these PRs to:
+{{- range .Authors }}
+    - @{{ . }}
+{{- end }}
+{{- else -}}
+- No PRs were merged in this release.
+{{- end }}
+`
+)
+
+var (
+	prRegexp   = regexp.MustCompile(prTitle)
+	clTemplate = template.Must(template.New("changelog").Parse(clFormat))
+)
+
+type commit struct {
+	Hash  string
+	Title string
+	Body  string
+}
+
+type pullRequest struct {
+	Number int
+	Author string
+	Commit commit
+}
+
+func git(args ...string) (io.Reader, error) {
+	cmd := exec.Command("git", args...)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	return bytes.NewReader(out), nil
+}
+
+func readLine(r io.Reader) (string, error) {
+	br := bufio.NewReader(r)
+	line, _, err := br.ReadLine()
+	if err != nil {
+		return "", err
+	}
+	return string(line), nil
+}
+
+// Gets the latest version tag in master
+func latestTag() (string, error) {
+	// Run git command
+	r, err := git("tag", "--list", "--sort=-version:refname", "--merged", branch, fmt.Sprintf("%s*", prefix))
+	if err != nil {
+		return "", err
+	}
+	// Read first line of output
+	return readLine(r)
+}
+
+// Finds commits in master since the specified revision in chronological order
+func commitsSince(rev string) ([]commit, error) {
+	// Run git command
+	r, err := git("log", "--format=%H %s", "--reverse", fmt.Sprintf("^%s", rev), branch)
+	if err != nil {
+		return nil, err
+	}
+
+	// Read and parse output
+	commits := make([]commit, 0)
+	s := bufio.NewScanner(r)
+	for s.Scan() {
+		// Split lines into commit hash and title
+		line := s.Text()
+		fields := strings.SplitN(line, " ", 2)
+		if len(fields) < 2 {
+			continue
+		}
+
+		c := commit{Hash: fields[0], Title: strings.TrimSpace(fields[1])}
+
+		// Get an additional line from the message of each commit
+		r, err := git("show", "--format=%b", c.Hash)
+		if err != nil {
+			return nil, err
+		}
+
+		line, err = readLine(r)
+		if err != nil {
+			return nil, err
+		}
+		c.Body = strings.TrimSpace(line)
+
+		commits = append(commits, c)
+	}
+
+	return commits, nil
+}
+
+// Finds PRs in the list of commits
+func parsePullRequests(commits []commit) []pullRequest {
+	prs := make([]pullRequest, 0)
+	for _, c := range commits {
+		// Find pull requests by their commit title
+		match := prRegexp.FindSubmatch([]byte(c.Title))
+		if match == nil {
+			continue
+		}
+
+		// Parse attributes in the title
+		n, _ := strconv.Atoi(string(match[1]))
+		pr := pullRequest{Number: n, Author: string(match[2]), Commit: c}
+
+		prs = append(prs, pr)
+	}
+
+	return prs
+}
+
+// Collects unique authors in the order of PRs
+func collectAuthors(prs []pullRequest) []string {
+	seen := make(map[string]bool)
+	authors := make([]string, 0)
+	for _, pr := range prs {
+		if len(pr.Author) == 0 {
+			continue
+		}
+		if _, ok := seen[pr.Author]; !ok {
+			authors = append(authors, pr.Author)
+		}
+	}
+	return authors
+}
+
+// usage: go run scripts/changelog.go [new version]
+func main() {
+	args := os.Args[1:]
+
+	version := "TBD"
+	if len(args) > 0 {
+		version = args[0]
+	}
+
+	tag, _ := latestTag()
+	commits, _ := commitsSince(tag)
+	prs := parsePullRequests(commits)
+	authors := collectAuthors(prs)
+
+	clTemplate.Execute(os.Stdout, struct {
+		Version, Date string
+		PullRequests  []pullRequest
+		Authors       []string
+	}{version, time.Now().Format("2006-01-02"), prs, authors})
+}


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.


Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->
# Fixes #79

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the development branch.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [x] I have added in line documentation to the code I modified

### Short description of what this PR does:
Added a script to generate a changelog entry for a new release with the list of merged PRs since the latest tagged release included.

As the original issue did not have detailed requirements, I made the following decisions during the implementation:
- The "script" is written in Go and git is its only dependency, as these are the 2 things which are expected to be available in any machine used for working on this repository
- As previous changelog entries mainly included single PRs I came up with a suggested format for handling multiple PRs per release
- The generated entry does not include the full name of PR authors for now, because this either needs communication with the GitHub API or some extra parsing locally through git
